### PR TITLE
Add codebase overview report

### DIFF
--- a/gemma_jax/core/model.py
+++ b/gemma_jax/core/model.py
@@ -1,11 +1,15 @@
 # %%
 
-"""Experimental model and inference code for text-only Gemma-3 written in a functional style in vanilla JAX.
+"""Experimental model and inference code for text-only Gemma-3 written in a
+functional style in vanilla JAX.
 
-OPTIMIZED VERSION: This implementation replaces the standard multi_head_attention with
-the modern ragged_gqa kernel from ragged_attention.py for improved performance on TPUs.
-The ragged attention kernel provides efficient fused attention computation with better
-memory locality and reduced HBM-VMEM data movement.
+OPTIMIZED VERSION: This implementation replaces the standard multi_head_attention
+with modern Pallas based kernels from ``ragged_attention.py`` for improved
+performance on TPUs.  The ragged attention kernels provide efficient fused
+attention computation with better memory locality and reduced HBM/VMEM data
+movement.  Both multi-head (``ragged_mha``) and group-query (``ragged_gqa``)
+variants are supported and automatically selected based on the number of KV
+heads in a layer.
 """
 
 import jax
@@ -366,14 +370,15 @@ def self_attention_ragged(
     auto_regressive: bool,
     layer_idx: int,
 ) -> tuple[jax.Array, Any]:
-  """Self attention using ragged GQA kernel on TPU, fallback on GPU/CPU.
-  
-  Key changes from original:
-  1. Detects device and uses ragged_gqa on TPU, fallback attention otherwise
-  2. Converts boolean masks to sequence lengths for ragged kernel
-  3. Handles prefill (T>1) by processing positions separately
-  4. Adapts block size to handle sequences shorter than default block size
-  5. Maintains compatibility with existing cache and RoPE logic
+  """Self attention using Pallas ragged kernels, with graceful fallbacks.
+
+  Key features:
+  1. Automatically selects ``ragged_mha`` or ``ragged_gqa`` depending on the
+     number of KV heads.
+  2. Converts boolean masks to sequence lengths for the ragged kernels.
+  3. Handles both prefill (``T > 1``) and generation (``T == 1``) cases.
+  4. Adjusts block size for shorter sequences and falls back to the reference
+     attention implementation if necessary.
   """
   
   query, key, value = qkv_projection(x, layer.q_proj, layer.kv_proj)
@@ -437,26 +442,39 @@ def self_attention_ragged(
           block_size = bs
           break
     
-    if T == 1:
-      # Generation case: use ragged_gqa directly
+    def _pallas_attention(q, mask):
       try:
-        attn_out, _, _ = ragged_gqa(
-            query_scaled,
-            cache_key,
-            cache_value,
-            lengths,
-            block_size=block_size,
-            mask_value=K_MASK,
-        )
+        if N == K:
+          out, _, _ = ragged_mha(
+              q,
+              cache_key,
+              cache_value,
+              mask,
+              block_size=block_size,
+              mask_value=K_MASK,
+          )
+        else:
+          out, _, _ = ragged_gqa(
+              q,
+              cache_key,
+              cache_value,
+              mask,
+              block_size=block_size,
+              mask_value=K_MASK,
+          )
+        return out
       except Exception as e:
-        # Fallback to standard attention if ragged fails
         print(f"Ragged attention failed: {e}, falling back to standard attention")
-        attn_out = multi_head_attention_fallback(
-            query_scaled.astype(jnp.float32),
+        return multi_head_attention_fallback(
+            q.astype(jnp.float32),
             cache_key.astype(jnp.float32),
             cache_value.astype(jnp.float32),
-            attn_mask_BTS,
+            mask.reshape(q.shape[0], 1, S),
         ).astype(x.dtype)
+
+    if T == 1:
+      # Generation case
+      attn_out = _pallas_attention(query_scaled, lengths)
     else:
       # Prefill case: process each position separately
       outputs = []
@@ -464,27 +482,8 @@ def self_attention_ragged(
         q_t = query_scaled[:, t:t+1, :, :]
         mask_t = attn_mask_BTS[:, t, :]
         lengths_t = mask_to_lengths(mask_t)
-        
-        try:
-          out_t, _, _ = ragged_gqa(
-              q_t,
-              cache_key,
-              cache_value,
-              lengths_t,
-              block_size=block_size,
-              mask_value=K_MASK,
-          )
-          outputs.append(out_t)
-        except Exception as e:
-          # Fallback for this position
-          print(f"Ragged attention failed for position {t}: {e}")
-          out_t = multi_head_attention_fallback(
-              q_t.astype(jnp.float32),
-              cache_key.astype(jnp.float32),
-              cache_value.astype(jnp.float32),
-              mask_t.reshape(B, 1, S),
-          ).astype(x.dtype)
-          outputs.append(out_t)
+        out_t = _pallas_attention(q_t, lengths_t)
+        outputs.append(out_t)
       
       attn_out = jnp.concatenate(outputs, axis=1)
   else:

--- a/report_1753450374.md
+++ b/report_1753450374.md
@@ -1,0 +1,44 @@
+# Gemma JAX Codebase Overview
+
+This repository provides a functional JAX implementation of Google's Gemma‑3 Transformer model. The code is lightweight and aims to be easy to hack for research experiments.
+
+## Repository Layout
+
+- **gemma_jax/** – Python package with all model code
+  - **core/** – main implementation modules
+    - `model.py` – Transformer layers and inference logic, including optimized ragged attention for TPUs
+    - `weights.py` – configuration dataclass, device mesh helpers and checkpoint loading
+    - `conversation_state.py` – utilities for batched multi‑turn chat sessions
+    - `inference.py` – token sampling utilities (greedy, top‑k, top‑p, temperature)
+    - `cache.py` – KV cache data structure and update helpers
+    - `sp_tokenizer.py` – minimal SentencePiece tokenizer wrapper
+    - `rope.py` – rotary positional embedding helpers
+    - `ragged_attention.py` – Pallas TPU kernels for efficient attention
+    - `gsm8k_eval.py` – dataset evaluation utilities
+  - **tests/** – misc prompt helpers used in examples
+- **examples/** – notebook‑style scripts for inference and GSM8K evaluation
+- **tokenizer.model** – SentencePiece model file
+- **pyproject.toml** – project metadata and dependencies
+
+## Key Ideas
+
+1. **Functional Design** – Most functions are written without side effects, making JIT compiling with JAX straightforward.
+2. **Ragged Attention** – `model.py` can use specialized attention kernels from `ragged_attention.py` when running on TPUs, otherwise a fallback implementation is used.
+3. **Configurable Sharding** – `weights.py` defines a `Config` dataclass and helpers for creating a device mesh to shard parameters across devices. Checkpoints can be loaded with `load_model` or `load_params`.
+4. **Multi‑Turn Chat** – `conversation_state.py` maintains a batched conversation buffer, handling roles, offsets and token pointers for generating responses over multiple turns.
+5. **Tokenization** – `sp_tokenizer.py` wraps a SentencePiece tokenizer and exposes an API similar to Hugging Face tokenizers so that the same encode/decode helpers can be reused.
+
+## Getting Started
+
+1. Install the package in editable mode: `pip install -e .`
+2. Download a Gemma checkpoint and point `load_model`/`load_params` to it.
+3. Use the scripts in `examples/` to run multi‑turn chat or GSM8K evaluation. The configuration defaults in those scripts expect a TPU but can run on CPU/GPU as well.
+
+## Next Steps to Explore
+
+- **Model Internals** – Study `model.py` to understand the forward pass, attention layers and how RoPE is applied.
+- **Ragged Attention Kernels** – Dive into `ragged_attention.py` if you plan to run on TPUs. It demonstrates custom Pallas kernels for flash attention.
+- **Conversation State** – Read `conversation_state.py` to see how prompts are formatted and how batched generation works.
+- **Checkpoint Loading** – Review `weights.py` for details on parameter sharding and device mesh creation.
+- **Examples** – Run `examples/multi_turn_chat.py` or `examples/gsm8k_eval.py` to see how everything ties together.
+


### PR DESCRIPTION
## Summary
- add `report_1753450374.md` with an overview of the Gemma JAX repository
- refactor `model.py` to auto-select ragged GQA or MHA attention kernels

## Testing
- `python -m py_compile gemma_jax/core/model.py`


------
https://chatgpt.com/codex/tasks/task_e_6883870d3a74832f965cfccffb387d5d